### PR TITLE
Allow hooks to commit changes instead of failing the commit

### DIFF
--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -78,6 +78,7 @@ MANIFEST_HOOK_DICT = cfgv.Map(
     cfgv.Optional('require_serial', cfgv.check_bool, False),
     cfgv.Optional('stages', cfgv.check_array(cfgv.check_one_of(C.STAGES)), []),
     cfgv.Optional('verbose', cfgv.check_bool, False),
+    cfgv.Optional('commit_changes', cfgv.check_bool, False),
 )
 MANIFEST_SCHEMA = cfgv.Array(MANIFEST_HOOK_DICT)
 

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -190,7 +190,9 @@ def _run_single_hook(
 
         if files_modified and can_commit_changes:
             git.update_changes()
-            diff_after = b''
+            # All changes should now be added -- there should no longer be any diff.
+            diff_after = _get_diff()
+            assert not diff_after
 
         if hook_failed:
             print_color = color.RED

--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -197,6 +197,11 @@ def commit(repo: str = '.') -> None:
     cmd_output_b(*cmd, cwd=repo, env=env)
 
 
+def update_changes(repo: str = '.') -> None:
+    cmd = ('git', 'add', '-u')
+    cmd_output_b(*cmd, cwd=repo)
+
+
 def git_path(name: str, repo: str = '.') -> str:
     _, out, _ = cmd_output('git', 'rev-parse', '--git-path', name, cwd=repo)
     return os.path.join(repo, out.strip())

--- a/pre_commit/hook.py
+++ b/pre_commit/hook.py
@@ -35,6 +35,7 @@ class Hook(NamedTuple):
     require_serial: bool
     stages: Sequence[str]
     verbose: bool
+    commit_changes: bool
 
     @property
     def cmd(self) -> Tuple[str, ...]:

--- a/pre_commit/staged_files_only.py
+++ b/pre_commit/staged_files_only.py
@@ -74,8 +74,16 @@ def _unstaged_changes_cleared(patch_dir: str) -> Generator[None, None, None]:
                 # We failed to apply the patch, presumably due to fixes made
                 # by hooks.
                 # Roll back the changes made by hooks.
-                cmd_output_b('git', 'restore', '--source', tree, '--worktree', '.', env=no_checkout_env)
+
+                # Save the current state of the index, as that could include partially staged files,
+                # a whole successful new commit, etc.
+                new_tree = cmd_output('git', 'write-tree')[1].strip()
+                # Restore worktree to the patch base (which unavoidably updates the index as a side effect).
+                cmd_output_b('git', 'checkout', tree, '--', '.', env=no_checkout_env)
+                # Apply patch.
                 _git_apply(patch_filename)
+                # Restore new saved index.
+                cmd_output_b('git', 'read-tree', new_tree, env=no_checkout_env)
 
             logger.info(f'Restored changes from {patch_filename}.')
     else:

--- a/pre_commit/staged_files_only.py
+++ b/pre_commit/staged_files_only.py
@@ -74,7 +74,7 @@ def _unstaged_changes_cleared(patch_dir: str) -> Generator[None, None, None]:
                 # We failed to apply the patch, presumably due to fixes made
                 # by hooks.
                 # Roll back the changes made by hooks.
-                cmd_output_b('git', 'checkout', '--', '.', env=no_checkout_env)
+                cmd_output_b('git', 'restore', '--source', tree, '--worktree', '.', env=no_checkout_env)
                 _git_apply(patch_filename)
 
             logger.info(f'Restored changes from {patch_filename}.')


### PR DESCRIPTION
Currently looks like this:
![image](https://user-images.githubusercontent.com/245905/126018069-cc21bd2b-956b-4245-8680-57838ca8225c.png)

One open question: should this be more visible to the user? (e.g. print a yellow "Fixed" or similar)