### PR TITLE
Normalize Metrics command

### DIFF
--- a/pre_commit/metrics.py
+++ b/pre_commit/metrics.py
@@ -1,5 +1,4 @@
 import json
-from locale import normalize
 import shlex
 import subprocess
 from contextlib import contextmanager

--- a/pre_commit/metrics.py
+++ b/pre_commit/metrics.py
@@ -1,10 +1,12 @@
 import json
+from locale import normalize
 import shlex
 import subprocess
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from datetime import timezone
+from pre_commit import parse_shebang
 from typing import Dict
 from typing import Generator
 from typing import List
@@ -72,7 +74,8 @@ class Monitor:
     def report_metrics(self) -> None:
         if self.report_command:
             record_json = json.dumps([record.for_json() for record in self.records])
-            subprocess.run(self.report_command + [record_json])
+            normalized_command = list(parse_shebang.normalize_cmd(tuple(self.report_command)))
+            subprocess.run(normalized_command + [record_json])
 
 
 monitor = Monitor()


### PR DESCRIPTION
The hook commands get normalized, meaning they work on Windows machines.  The metrics command doesn't, resulting in pre-commit failure on Windows when given the same path to clyde as the hooks.

This normalizes that command so we can report metrics and thus pass pre-commit.  Tested locally on my Windows machine.