### PR TITLE
enable output streaming

### DIFF
--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -232,6 +232,7 @@ MANIFEST_HOOK_DICT = cfgv.Map(
     StagesMigration('stages', []),
     cfgv.Optional('verbose', cfgv.check_bool, False),
     cfgv.Optional('commit_changes', cfgv.check_bool, False),
+    cfgv.Optional('stream_output', cfgv.check_bool, False),
 )
 MANIFEST_SCHEMA = cfgv.Array(MANIFEST_HOOK_DICT)
 

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -184,6 +184,7 @@ def _run_single_hook(
                     is_local=hook.src == 'local',
                     require_serial=hook.require_serial,
                     color=use_color,
+                    stream_output=hook.stream_output,
                 )
             duration = round(time.monotonic() - time_before, 2) or 0
             diff_after = _get_diff()
@@ -209,7 +210,13 @@ def _run_single_hook(
             print_color = color.GREEN
             status = 'Passed'
 
-        output.write_line(color.format_color(status, print_color, use_color))
+        if hook.stream_output:
+            output.write(color.format_color(status, print_color, use_color))
+        else:
+            output.write_line(color.format_color(status, print_color, use_color))
+
+    if hook.stream_output:
+        output.write_b(b'\0338')
 
     if verbose or hook.verbose or retcode or files_modified:
         _subtle_line(f'- hook id: {hook.id}', use_color)

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -215,8 +215,10 @@ def _run_single_hook(
         else:
             output.write_line(color.format_color(status, print_color, use_color))
 
+    # If the hook is streaming output, then we've saved the cursor position at the end of the output of the hook
+    # and moved the cursor back to the beginning to print the status result.
     if hook.stream_output:
-        output.write_b(b'\0338')
+        output.write_b(b'\0338')  # Restore cursor to saved position
 
     if verbose or hook.verbose or retcode or files_modified:
         _subtle_line(f'- hook id: {hook.id}', use_color)

--- a/pre_commit/hook.py
+++ b/pre_commit/hook.py
@@ -36,6 +36,7 @@ class Hook(NamedTuple):
     stages: Sequence[str]
     verbose: bool
     commit_changes: bool
+    stream_output: bool
 
     @property
     def install_key(self) -> tuple[Prefix, str, str, tuple[str, ...]]:

--- a/pre_commit/lang_base.py
+++ b/pre_commit/lang_base.py
@@ -11,6 +11,7 @@ from typing import Any
 from typing import ContextManager
 from typing import NoReturn
 from typing import Protocol
+from typing import Optional
 
 import pre_commit.constants as C
 from pre_commit import parse_shebang
@@ -55,7 +56,7 @@ class Language(Protocol):
             is_local: bool,
             require_serial: bool,
             color: bool,
-            stream_output: bool | None,
+            stream_output: Optional[bool],
     ) -> tuple[int, bytes]:
         ...
 
@@ -159,7 +160,7 @@ def run_xargs(
         *,
         require_serial: bool,
         color: bool,
-        stream_output: bool | None,
+        stream_output: Optional[bool],
 ) -> tuple[int, bytes]:
     if require_serial:
         jobs = 1

--- a/pre_commit/lang_base.py
+++ b/pre_commit/lang_base.py
@@ -55,6 +55,7 @@ class Language(Protocol):
             is_local: bool,
             require_serial: bool,
             color: bool,
+            stream_output: bool | None,
     ) -> tuple[int, bytes]:
         ...
 
@@ -158,6 +159,7 @@ def run_xargs(
         *,
         require_serial: bool,
         color: bool,
+        stream_output: bool | None,
 ) -> tuple[int, bytes]:
     if require_serial:
         jobs = 1
@@ -167,7 +169,7 @@ def run_xargs(
         # ordering.
         file_args = _shuffled(file_args)
         jobs = target_concurrency()
-    return xargs.xargs(cmd, file_args, target_concurrency=jobs, color=color)
+    return xargs.xargs(cmd, file_args, target_concurrency=jobs, color=color, stream_output=stream_output)
 
 
 def hook_cmd(entry: str, args: Sequence[str]) -> tuple[str, ...]:
@@ -183,10 +185,12 @@ def basic_run_hook(
         is_local: bool,
         require_serial: bool,
         color: bool,
+        stream_output: bool | None,
 ) -> tuple[int, bytes]:
     return run_xargs(
         hook_cmd(entry, args),
         file_args,
         require_serial=require_serial,
         color=color,
+        stream_output=stream_output,
     )

--- a/pre_commit/languages/script.py
+++ b/pre_commit/languages/script.py
@@ -21,6 +21,7 @@ def run_hook(
         is_local: bool,
         require_serial: bool,
         color: bool,
+        stream_output: bool | None,
 ) -> tuple[int, bytes]:
     cmd = lang_base.hook_cmd(entry, args)
     cmd = (prefix.path(cmd[0]), *cmd[1:])
@@ -29,4 +30,6 @@ def run_hook(
         file_args,
         require_serial=require_serial,
         color=color,
+        stream_output=stream_output,
     )
+

--- a/pre_commit/languages/script.py
+++ b/pre_commit/languages/script.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import Optional
 
 from pre_commit import lang_base
 from pre_commit.prefix import Prefix
@@ -21,7 +22,7 @@ def run_hook(
         is_local: bool,
         require_serial: bool,
         color: bool,
-        stream_output: bool | None,
+        stream_output: Optional[bool],
 ) -> tuple[int, bytes]:
     cmd = lang_base.hook_cmd(entry, args)
     cmd = (prefix.path(cmd[0]), *cmd[1:])

--- a/pre_commit/xargs.py
+++ b/pre_commit/xargs.py
@@ -222,8 +222,9 @@ def xargs(
 
         for chunk, maybe_returncode in stream_subprocess_output(cmd):
             output += chunk
-            sys.stdout.buffer.write(chunk)
-            sys.stdout.buffer.flush()
+            with stdout_lock:
+                sys.stdout.buffer.write(chunk)
+                sys.stdout.buffer.flush()
             if maybe_returncode is not None:
                 returncode = maybe_returncode
 


### PR DESCRIPTION
Currently, hooks are either silent or verbose. With verbose, they will print their stdout after the hook completes. This isn't helpful when a hook takes a long time, since pre-commit will hang without output while the hook runs.

These changes add another option to pre-commit configurations: `stream_output`, which will do what it says.
There's some logic here to move the cursor around so that it still prints the result on the correct line and moves back to where it last ended output. This also will likely not be used most of the time, but there are a few cases where it will be useful. In particular, we'll probably want to use it on any hook that takes >5-10 seconds on average. I also plan to add logic for checking if the clyde env needs to be updated (might be worth adding this as a default check since 62/68 pre-commit hooks invoke clyde atm), in which case we would definitely want to stream the output.