### PR TITLE
use output module and reprint start if necessary

### DIFF
--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -168,7 +168,8 @@ def _run_single_hook(
         out = b''
     else:
         # print hook and dots first in case the hook takes a while to run
-        output.write(_start_msg(start=hook.name, end_len=6, cols=cols))
+        start_msg = _start_msg(start=hook.name, end_len=6, cols=cols)
+        output.write(start_msg)
 
         if not hook.pass_filenames:
             filenames = ()
@@ -185,6 +186,7 @@ def _run_single_hook(
                     require_serial=hook.require_serial,
                     color=use_color,
                     stream_output=hook.stream_output,
+                    start_msg=start_msg,
                 )
             duration = round(time.monotonic() - time_before, 2) or 0
             diff_after = _get_diff()

--- a/pre_commit/lang_base.py
+++ b/pre_commit/lang_base.py
@@ -57,6 +57,7 @@ class Language(Protocol):
             require_serial: bool,
             color: bool,
             stream_output: Optional[bool],
+            start_msg: Optional[str],
     ) -> tuple[int, bytes]:
         ...
 
@@ -161,6 +162,7 @@ def run_xargs(
         require_serial: bool,
         color: bool,
         stream_output: Optional[bool],
+        start_msg: Optional[str],
 ) -> tuple[int, bytes]:
     if require_serial:
         jobs = 1
@@ -170,7 +172,14 @@ def run_xargs(
         # ordering.
         file_args = _shuffled(file_args)
         jobs = target_concurrency()
-    return xargs.xargs(cmd, file_args, target_concurrency=jobs, color=color, stream_output=stream_output)
+    return xargs.xargs(
+        cmd,
+        file_args,
+        target_concurrency=jobs,
+        color=color,
+        stream_output=stream_output,
+        start_msg=start_msg,
+    )
 
 
 def hook_cmd(entry: str, args: Sequence[str]) -> tuple[str, ...]:

--- a/pre_commit/languages/script.py
+++ b/pre_commit/languages/script.py
@@ -23,6 +23,7 @@ def run_hook(
         require_serial: bool,
         color: bool,
         stream_output: Optional[bool],
+        start_msg: Optional[str],
 ) -> tuple[int, bytes]:
     cmd = lang_base.hook_cmd(entry, args)
     cmd = (prefix.path(cmd[0]), *cmd[1:])
@@ -31,6 +32,7 @@ def run_hook(
         file_args,
         require_serial=require_serial,
         color=color,
+        start_msg=start_msg,
         stream_output=stream_output,
     )
 


### PR DESCRIPTION
If the original status message scrolls out of view, then this will no longer be able to reposition the cursor correctly for updating the status. In that case, this will now reprint the status message at the end of the output.

Also use the builtin output modules which handles the stdout lock.