### PR TITLE
pass start_msg to basic_run_hook

### DIFF
--- a/pre_commit/lang_base.py
+++ b/pre_commit/lang_base.py
@@ -195,7 +195,8 @@ def basic_run_hook(
         is_local: bool,
         require_serial: bool,
         color: bool,
-        stream_output: bool | None,
+        stream_output: Optional[bool],
+        start_msg: Optional[str],
 ) -> tuple[int, bytes]:
     return run_xargs(
         hook_cmd(entry, args),
@@ -203,4 +204,5 @@ def basic_run_hook(
         require_serial=require_serial,
         color=color,
         stream_output=stream_output,
+        start_msg=start_msg,
     )

--- a/pre_commit/languages/docker.py
+++ b/pre_commit/languages/docker.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import os
 from collections.abc import Sequence
+from typing import Optional
 
 from pre_commit import lang_base
 from pre_commit.prefix import Prefix
@@ -135,6 +136,8 @@ def run_hook(
         is_local: bool,
         require_serial: bool,
         color: bool,
+        stream_output: Optional[bool],
+        start_msg: Optional[str],
 ) -> tuple[int, bytes]:  # pragma: win32 no cover
     # Rebuild the docker image in case it has gone missing, as many people do
     # automated cleanup of docker images.
@@ -148,4 +151,7 @@ def run_hook(
         file_args,
         require_serial=require_serial,
         color=color,
+        stream_output=stream_output,
+        start_msg=start_msg,
     )
+

--- a/pre_commit/languages/docker_image.py
+++ b/pre_commit/languages/docker_image.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import Optional
 
 from pre_commit import lang_base
 from pre_commit.languages.docker import docker_cmd
@@ -22,6 +23,8 @@ def run_hook(
         is_local: bool,
         require_serial: bool,
         color: bool,
+        stream_output: Optional[bool],
+        start_msg: Optional[str],
 ) -> tuple[int, bytes]:  # pragma: win32 no cover
     cmd = docker_cmd(color=color) + lang_base.hook_cmd(entry, args)
     return lang_base.run_xargs(
@@ -29,4 +32,6 @@ def run_hook(
         file_args,
         require_serial=require_serial,
         color=color,
+        stream_output=stream_output,
+        start_msg=start_msg,
     )

--- a/pre_commit/languages/julia.py
+++ b/pre_commit/languages/julia.py
@@ -5,6 +5,7 @@ import os
 import shutil
 from collections.abc import Generator
 from collections.abc import Sequence
+from typing import Optional
 
 from pre_commit import lang_base
 from pre_commit.envcontext import envcontext
@@ -27,6 +28,8 @@ def run_hook(
         is_local: bool,
         require_serial: bool,
         color: bool,
+        stream_output: Optional[bool],
+        start_msg: Optional[str],
 ) -> tuple[int, bytes]:
     # `entry` is a (hook-repo relative) file followed by (optional) args, e.g.
     # `bin/id.jl` or `bin/hook.jl --arg1 --arg2` so we
@@ -43,6 +46,8 @@ def run_hook(
         file_args,
         require_serial=require_serial,
         color=color,
+        stream_output=stream_output,
+        start_msg=start_msg,
     )
 
 

--- a/pre_commit/languages/r.py
+++ b/pre_commit/languages/r.py
@@ -8,6 +8,7 @@ import tempfile
 import textwrap
 from collections.abc import Generator
 from collections.abc import Sequence
+from typing import Optional
 
 from pre_commit import lang_base
 from pre_commit.envcontext import envcontext
@@ -244,6 +245,8 @@ def run_hook(
         is_local: bool,
         require_serial: bool,
         color: bool,
+        stream_output: Optional[bool],
+        start_msg: Optional[str],
 ) -> tuple[int, bytes]:
     cmd = _cmd_from_hook(prefix, entry, args, is_local=is_local)
     return lang_base.run_xargs(
@@ -251,4 +254,6 @@ def run_hook(
         file_args,
         require_serial=require_serial,
         color=color,
+        stream_output=stream_output,
+        start_msg=start_msg,
     )


### PR DESCRIPTION
Not all hooks were properly configured to receive the `start_msg` arg. In particular, `node` hooks like `prettier` go through the `lang_base` hook (this and `software-definition-update` are the only hooks that go through this path). While I'm here, I figured I might as well add it to every other hook type regardless of if we actually use them, so no hook will ever fail on this.