### PR TITLE
Update the git commit message header to support "scissors"

### DIFF
--- a/pre_commit/editor.py
+++ b/pre_commit/editor.py
@@ -26,6 +26,7 @@ T = TypeVar('T')
 COMMIT_MESSAGE_DRAFT_PATH = Path('.git/pre-commit/COMMIT_EDITMSG')
 COMMIT_MESSAGE_EXPIRED_DRAFT_PATH = Path('.git/pre-commit/COMMIT_EDITMSG_OLD')
 COMMIT_MESSAGE_HEADER = """
+# ------------------------ >8 ------------------------
 # Please enter the commit message for your changes. Lines starting
 # with '#' will be ignored, and an empty message aborts the commit.
 #


### PR DESCRIPTION
Because as-is this cleanup mode is being ignored.

As a new hire, I did not realize the default commit message template was being overwritten and accidentally committed comments (see discord commit: 093059f2a50).

[Documentation for cleanup modes](https://github.com/git/git/blob/75df1f434f8cfdac1c8eeacae259ab375c01385b/Documentation/git-commit.txt#L176-L197).

If curious, the reason why I prefer `scissors` is because I like to write commit messages using markdown since several VCS platforms (including github) will render the markdown. `scissors` prevents headers from being removed.

This does not help anyone who prefers to use `verbatim`.