### PR TITLE
[config] enable exclusion by os

### DIFF
--- a/pre_commit/clientlib.py
+++ b/pre_commit/clientlib.py
@@ -233,6 +233,7 @@ MANIFEST_HOOK_DICT = cfgv.Map(
     cfgv.Optional('verbose', cfgv.check_bool, False),
     cfgv.Optional('commit_changes', cfgv.check_bool, False),
     cfgv.Optional('stream_output', cfgv.check_bool, False),
+    cfgv.Optional('exclude_os', cfgv.check_array(cfgv.check_string), []),
 )
 MANIFEST_SCHEMA = cfgv.Array(MANIFEST_HOOK_DICT)
 

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -5,6 +5,7 @@ import contextlib
 import functools
 import logging
 import os
+import platform
 import re
 import subprocess
 import time
@@ -455,11 +456,14 @@ def run(
 
         config = load_config(config_file)
         monitor.set_report_command(config['metrics_command'])
+
+        current_os = platform.system().lower()
         hooks = [
             hook
             for hook in all_hooks(config, store)
             if not args.hook or hook.id == args.hook or hook.alias == args.hook
             if args.hook_stage in hook.stages
+            if current_os not in hook.exclude_os
         ]
 
         if args.hook and not hooks:
@@ -491,4 +495,3 @@ def run(
 
     # https://github.com/python/mypy/issues/7726
     raise AssertionError('unreachable')
-

--- a/pre_commit/hook.py
+++ b/pre_commit/hook.py
@@ -37,6 +37,7 @@ class Hook(NamedTuple):
     verbose: bool
     commit_changes: bool
     stream_output: bool
+    exclude_os: Sequence[str]
 
     @property
     def install_key(self) -> tuple[Prefix, str, str, tuple[str, ...]]:


### PR DESCRIPTION
This adds a config option to hooks: `exclude_os`, a list of strings that can be used to exclude a platform from running that hook. This will mainly be used to improve the pre-commit experience on Windows.