### PR TITLE
[clyde] auto-update venv if necessary

### DIFF
--- a/pre_commit/resources/hook-tmpl
+++ b/pre_commit/resources/hook-tmpl
@@ -8,6 +8,19 @@ ARGS=(hook-impl)
 # end templated
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
+
+REPO_ROOT="${HERE}/../.."
+export CLYDE_ROOT="${REPO_ROOT}/discord_clyde"
+if [[ "$(uname)" = MINGW* ]] || [[ "$(uname)" = MSYS* ]]; then
+    export CLYDE_ENV="${INSTALL_PYTHON/Scripts\/python.exe/}"
+else
+    export CLYDE_ENV="${INSTALL_PYTHON%/bin/python}"
+fi
+
+if "${CLYDE_ROOT}/setup/detect_changes.sh" has_diverged_from_tracking '-E "setup.py|requirements.txt"'; then
+    "${REPO_ROOT}/clyde" noop
+fi
+
 ARGS+=(--hook-dir "$HERE" -- "$@")
 
 if [ -x "$INSTALL_PYTHON" ]; then

--- a/pre_commit/resources/hook-tmpl
+++ b/pre_commit/resources/hook-tmpl
@@ -9,17 +9,19 @@ ARGS=(hook-impl)
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 
-REPO_ROOT="${HERE}/../.."
-export CLYDE_ROOT="${REPO_ROOT}/discord_clyde"
-if [[ "$(uname)" = MINGW* ]] || [[ "$(uname)" = MSYS* ]]; then
-    export CLYDE_ENV="${INSTALL_PYTHON%\\Scripts\\python.exe}"
-else
-    export CLYDE_ENV="${INSTALL_PYTHON%/bin/python}"
-fi
+(
+    REPO_ROOT="${HERE}/../.."
+    export CLYDE_ROOT="${REPO_ROOT}/discord_clyde"
+    if [[ "$(uname)" = MINGW* ]] || [[ "$(uname)" = MSYS* ]]; then
+        export CLYDE_ENV="${INSTALL_PYTHON%\\Scripts\\python.exe}"
+    else
+        export CLYDE_ENV="${INSTALL_PYTHON%/bin/python}"
+    fi
 
-if "${CLYDE_ROOT}/setup/detect_changes.sh" has_diverged_from_tracking '-E "setup.py|requirements.txt"'; then
-    "${REPO_ROOT}/clyde" noop
-fi
+    if "${CLYDE_ROOT}/setup/detect_changes.sh" has_diverged_from_tracking '-E "setup.py|requirements.txt"'; then
+        "${REPO_ROOT}/clyde" noop
+    fi
+)
 
 ARGS+=(--hook-dir "$HERE" -- "$@")
 

--- a/pre_commit/resources/hook-tmpl
+++ b/pre_commit/resources/hook-tmpl
@@ -12,7 +12,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="${HERE}/../.."
 export CLYDE_ROOT="${REPO_ROOT}/discord_clyde"
 if [[ "$(uname)" = MINGW* ]] || [[ "$(uname)" = MSYS* ]]; then
-    export CLYDE_ENV="${INSTALL_PYTHON/Scripts\/python.exe/}"
+    export CLYDE_ENV="${INSTALL_PYTHON%\\Scripts\\python.exe}"
 else
     export CLYDE_ENV="${INSTALL_PYTHON%/bin/python}"
 fi

--- a/pre_commit/resources/hook-tmpl-pro
+++ b/pre_commit/resources/hook-tmpl-pro
@@ -9,17 +9,19 @@ ARGS=(hook-impl)
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 
-REPO_ROOT="${HERE}/../.."
-export CLYDE_ROOT="${REPO_ROOT}/discord_clyde"
-if [[ "$(uname)" = MINGW* ]] || [[ "$(uname)" = MSYS* ]]; then
-    export CLYDE_ENV="${INSTALL_PYTHON%\\Scripts\\python.exe}"
-else
-    export CLYDE_ENV="${INSTALL_PYTHON%/bin/python}"
-fi
+(
+    REPO_ROOT="${HERE}/../.."
+    export CLYDE_ROOT="${REPO_ROOT}/discord_clyde"
+    if [[ "$(uname)" = MINGW* ]] || [[ "$(uname)" = MSYS* ]]; then
+        export CLYDE_ENV="${INSTALL_PYTHON%\\Scripts\\python.exe}"
+    else
+        export CLYDE_ENV="${INSTALL_PYTHON%/bin/python}"
+    fi
 
-if "${CLYDE_ROOT}/setup/detect_changes.sh" has_diverged_from_tracking '-E "setup.py|requirements.txt"'; then
-    "${REPO_ROOT}/clyde" noop
-fi
+    if "${CLYDE_ROOT}/setup/detect_changes.sh" has_diverged_from_tracking '-E "setup.py|requirements.txt"'; then
+        "${REPO_ROOT}/clyde" noop
+    fi
+)
 
 COMMIT_ARGS+=(--hook-dir "$HERE" --)
 PUSH_ARGS+=(--hook-dir "$HERE" -- "$@")

--- a/pre_commit/resources/hook-tmpl-pro
+++ b/pre_commit/resources/hook-tmpl-pro
@@ -12,7 +12,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="${HERE}/../.."
 export CLYDE_ROOT="${REPO_ROOT}/discord_clyde"
 if [[ "$(uname)" = MINGW* ]] || [[ "$(uname)" = MSYS* ]]; then
-    export CLYDE_ENV="${INSTALL_PYTHON/Scripts\/python.exe/}"
+    export CLYDE_ENV="${INSTALL_PYTHON%\\Scripts\\python.exe}"
 else
     export CLYDE_ENV="${INSTALL_PYTHON%/bin/python}"
 fi

--- a/pre_commit/resources/hook-tmpl-pro
+++ b/pre_commit/resources/hook-tmpl-pro
@@ -8,6 +8,19 @@ ARGS=(hook-impl)
 # end templated
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
+
+REPO_ROOT="${HERE}/../.."
+export CLYDE_ROOT="${REPO_ROOT}/discord_clyde"
+if [[ "$(uname)" = MINGW* ]] || [[ "$(uname)" = MSYS* ]]; then
+    export CLYDE_ENV="${INSTALL_PYTHON/Scripts\/python.exe/}"
+else
+    export CLYDE_ENV="${INSTALL_PYTHON%/bin/python}"
+fi
+
+if "${CLYDE_ROOT}/setup/detect_changes.sh" has_diverged_from_tracking '-E "setup.py|requirements.txt"'; then
+    "${REPO_ROOT}/clyde" noop
+fi
+
 COMMIT_ARGS+=(--hook-dir "$HERE" --)
 PUSH_ARGS+=(--hook-dir "$HERE" -- "$@")
 


### PR DESCRIPTION
This makes pre-commit check for updates before running. This will be useful for anytime pre-commit has changes. There are times when we depend on pre-commit being up to date, but it doesn't update until after it actually starts and inevitably invokes `clyde`, which prompts the self update. Additionally, this will allow us to separate the update logic from the `git commit check`. For the initial check, isn't of simply running `clyde noop` which takes ~300ms, this uses the same script that `clyde` itself uses to check for updates. Running this script alone only takes ~30ms, which seems like an acceptable cost for a no-op.