### PR TITLE
[hooks] change flags for manual invocations

### DIFF
--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -317,8 +317,8 @@ def hook_impl(
         hook_dir: str,
         skip_on_missing_config: bool,
         manual: bool,
-        ignore_unstaged: bool,
-        all_commits: bool,
+        staged: bool,
+        unstaged: bool,
         args: Sequence[str],
 ) -> int:
     retv, stdin = _run_legacy(hook_type, hook_dir, args)
@@ -327,4 +327,4 @@ def hook_impl(
     if ns is None:
         return retv
     else:
-        return retv | run(config, store, ns, manual, ignore_unstaged, all_commits)
+        return retv | run(config, store, ns, manual, staged, unstaged)

--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -133,7 +133,7 @@ def get_conflicted_files() -> set[str]:
     return set(merge_conflict_filenames) | set(merge_diff_filenames)
 
 
-def get_uncommitted_files(cwd: str | None = None) -> list[str]:
+def get_staged_and_unstaged_files(cwd: str | None = None) -> list[str]:
     return zsplit(
         cmd_output(
             'git', 'diff', '--name-only', '--no-ext-diff', '-z',

--- a/pre_commit/main.py
+++ b/pre_commit/main.py
@@ -354,8 +354,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         '--skip-on-missing-config', action='store_true',
     )
     hook_impl_parser.add_argument('--manual', action='store_true')
-    hook_impl_parser.add_argument('--ignore-unstaged', action='store_true', default=False)
-    hook_impl_parser.add_argument('--all-commits', action='store_true')
+    hook_impl_parser.add_argument('--staged', action='store_true')
+    hook_impl_parser.add_argument('--unstaged', action='store_true')
     hook_impl_parser.add_argument(dest='rest', nargs=argparse.REMAINDER)
 
     # argparse doesn't really provide a way to use a `default` subparser
@@ -398,8 +398,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                 hook_dir=args.hook_dir,
                 skip_on_missing_config=args.skip_on_missing_config,
                 manual=args.manual,
-                ignore_unstaged=args.ignore_unstaged,
-                all_commits=args.all_commits,
+                staged=args.staged,
+                unstaged=args.unstaged,
                 args=args.rest[1:],
             )
         elif args.command == 'install':


### PR DESCRIPTION
This changes the flags so the behavior for manually invoking pre-commit hooks (via `clyde check`) is slightly more intuitive.

I imagine this command will mostly be utilized by people who have deferred pre-commit checks to pre-push, or have disabled them entirely. So this should check against all diverged files by default. If the user wants to check against staged files only, then `--staged` should be provided, or `--unstaged` for unstaged only. Or optionally, both.