### PR TITLE
[metrics] write to metrics file

### DIFF
--- a/pre_commit/metrics.py
+++ b/pre_commit/metrics.py
@@ -5,7 +5,8 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from datetime import timezone
-from pre_commit import parse_shebang
+from pathlib import Path
+from pre_commit import git, parse_shebang
 from typing import Dict
 from typing import Generator
 from typing import List
@@ -72,9 +73,12 @@ class Monitor:
 
     def report_metrics(self) -> None:
         if self.report_command:
-            record_json = json.dumps([record.for_json() for record in self.records])
+            root = git.get_root()
+            metrics_file = Path(root) / 'discord_clyde' / '.metrics.json'
+            with open(metrics_file, 'w') as f:
+                json.dump([record.for_json() for record in self.records], f)
             normalized_command = list(parse_shebang.normalize_cmd(tuple(self.report_command)))
-            subprocess.run(normalized_command + [record_json])
+            subprocess.run(normalized_command)
 
 
 monitor = Monitor()


### PR DESCRIPTION
Just write to the metrics file so Windows stops failing on the metrics command (which emits a warning at the end of the pre-commit). Windows tends to fail here, passing JSON string through subprocess to Git Bash, which does some transformations on the string before passing it incorrectly to the clyde metrics command. 