### PR TITLE
[windows] fix editor path

### DIFF
--- a/pre_commit/commands/install_uninstall.py
+++ b/pre_commit/commands/install_uninstall.py
@@ -104,7 +104,7 @@ def _install_hook_script(
                 pass
             elif config_process.returncode != 0:
                 # No local editor set; configure integration.
-                subprocess.call(['git', 'config', '--local', 'core.editor', git.get_editor_script_path()])
+                subprocess.call(['git', 'config', '--local', 'core.editor', target_editor])
             else:
                 # Local editor differently configured; do not overwrite user config.
                 logger.error(

--- a/pre_commit/git.py
+++ b/pre_commit/git.py
@@ -247,7 +247,8 @@ def update_changes_concurrent(repo: str = '.') -> None:
 def get_editor_script_path(repo: str = '.') -> str:
     # In spite of being in the hooks directory, the editor script isn't a real hook as far as git is
     # concerned. We're putting it there as a convenient way to keep things in one place.
-    return os.path.join(repo, get_git_dir(repo), 'hooks', 'editor')
+    import posixpath
+    return posixpath.join(repo, get_git_dir(repo), 'hooks', 'editor')
 
 
 def update_changes(repo: str = '.') -> None:


### PR DESCRIPTION
This ends up setting the path with a proper Windows path using backslashes, but this doesn't appear to work when called as a Git hook. Using posix path here fixes the git editor hook on Windows. 