### PR TITLE
[precommit] fix run cmd, remove required positional args

### DIFF
--- a/pre_commit/commands/hook_impl.py
+++ b/pre_commit/commands/hook_impl.py
@@ -316,9 +316,9 @@ def hook_impl(
         hook_type: str,
         hook_dir: str,
         skip_on_missing_config: bool,
-        manual: bool,
-        staged: bool,
-        unstaged: bool,
+        manual: bool = False,
+        staged: bool = False,
+        unstaged: bool = False,
         args: Sequence[str],
 ) -> int:
     retv, stdin = _run_legacy(hook_type, hook_dir, args)

--- a/pre_commit/commands/run.py
+++ b/pre_commit/commands/run.py
@@ -365,9 +365,9 @@ def run(
         config_file: str,
         store: Store,
         args: argparse.Namespace,
-        manual: bool,
-        staged: bool,
-        unstaged: bool,
+        manual: bool = False,
+        staged: bool = False,
+        unstaged: bool = False,
         environ: MutableMapping[str, str] = os.environ,
 ) -> int:
     stash = not args.all_files and not args.files


### PR DESCRIPTION
These were preventing `pre_commit run` from being called, which is used by the nelly pre-commit CI test.