### PR TITLE
[resources] include editor tmpl in setup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ pre_commit.resources =
     *.tar.gz
     empty_template_*
     hook-tmpl
+    editor-tmpl
 
 [bdist_wheel]
 universal = True


### PR DESCRIPTION
`uv` doesn't install this fork of `precommit` as an editable dep, and some files turned out to be missing, which resulted in this error:

```
An unexpected error has occurred: FileNotFoundError: [Errno 2] No such file or directory: '/Users/peter.cho/.virtualenvs/clyde-env-be409fc97ce6f0677bb3cec0acf36281-3.11-arm-uv/lib/python3.11/site-packages/pre_commit/resources/editor-tmpl'
```