### PR TITLE
[hook-tmpl] remove clyde noop

### DIFF
--- a/pre_commit/resources/hook-tmpl
+++ b/pre_commit/resources/hook-tmpl
@@ -8,21 +8,6 @@ ARGS=(hook-impl)
 # end templated
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
-
-(
-    REPO_ROOT="${HERE}/../.."
-    export CLYDE_ROOT="${REPO_ROOT}/discord_clyde"
-    if [[ "$(uname)" = MINGW* ]] || [[ "$(uname)" = MSYS* ]]; then
-        export CLYDE_ENV="${INSTALL_PYTHON%\\Scripts\\python.exe}"
-    else
-        export CLYDE_ENV="${INSTALL_PYTHON%/bin/python}"
-    fi
-
-    if "${CLYDE_ROOT}/setup/detect_changes.sh" has_diverged_from_tracking '-E "setup.py|requirements.txt"'; then
-        "${REPO_ROOT}/clyde" noop
-    fi
-)
-
 ARGS+=(--hook-dir "$HERE" -- "$@")
 
 if [ -x "$INSTALL_PYTHON" ]; then

--- a/pre_commit/resources/hook-tmpl-pro
+++ b/pre_commit/resources/hook-tmpl-pro
@@ -8,21 +8,6 @@ ARGS=(hook-impl)
 # end templated
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
-
-(
-    REPO_ROOT="${HERE}/../.."
-    export CLYDE_ROOT="${REPO_ROOT}/discord_clyde"
-    if [[ "$(uname)" = MINGW* ]] || [[ "$(uname)" = MSYS* ]]; then
-        export CLYDE_ENV="${INSTALL_PYTHON%\\Scripts\\python.exe}"
-    else
-        export CLYDE_ENV="${INSTALL_PYTHON%/bin/python}"
-    fi
-
-    if "${CLYDE_ROOT}/setup/detect_changes.sh" has_diverged_from_tracking '-E "setup.py|requirements.txt"'; then
-        "${REPO_ROOT}/clyde" noop
-    fi
-)
-
 COMMIT_ARGS+=(--hook-dir "$HERE" --)
 PUSH_ARGS+=(--hook-dir "$HERE" -- "$@")
 


### PR DESCRIPTION
This fixes the error that occurs in pre-commit (more like a warning since it doesn't stop the pre-commit run):

```
error: Project virtual environment directory `/Users/petercho/.virtualenvs/clyde-env-b1eae0f56d9c68c30341b0556db030f8-3.11-arm-uv/bin/python3` cannot be used because expected directory but found a file
```

This error occurred due to outdated logic that relied on the old method of clyde venv setup before we migrated to `uv`. Instead of fixing this logic, we can just remove this entirely. This was here to ensure that if the clyde venv had to update itself, we would do it at the beginning of pre-commit apart from any individual hook because venv updates often used to take around a minute. Since we're on `uv` now, venv updates are barely noticeable, so let's just keep it simple and remove this.